### PR TITLE
using turbolinks and jquery datatables in rails 6

### DIFF
--- a/app/javascript/packs/users/index.js
+++ b/app/javascript/packs/users/index.js
@@ -3,7 +3,7 @@ import "admin-lte/plugins/datatables-bs4/js/dataTables.bootstrap4.min.js";
 import "admin-lte/plugins/datatables-responsive/js/dataTables.responsive.min.js";
 import "admin-lte/plugins/datatables-responsive/js/responsive.bootstrap4.min.js";
 
-$(function () {
+$( document ).on('turbolinks:load', function() {
   $("#users_example").DataTable({
     paging: true,
     lengthChange: true,


### PR DESCRIPTION
![스크린샷 2020-10-26 오전 8 48 01](https://user-images.githubusercontent.com/24658230/97122269-030aa900-1768-11eb-9d93-8b978da3b7ea.png)

Turbolinks must loaded first, because the top and bottom are overlapped.